### PR TITLE
Compilation improvement.

### DIFF
--- a/autoload/gnat.vim
+++ b/autoload/gnat.vim
@@ -119,7 +119,8 @@ function gnat#New ()						     " {{{1
       \ 'Tags_Command'     : '"gnat xref -P " . self.Project_File . " -v  *.AD*"',
       \ 'Error_Format'     : '%f:%l:%c: %trror: %m,'   .
 			   \ '%f:%l:%c: %tarning: %m,' .
-			   \ '%f:%l:%c: (%ttyle) %m'}
+			   \ '%f:%l:%c: (%ttyle) %m,'  .
+			   \ '%f:%l:%c: %m'}
 
    return l:Retval
 endfunction gnat#New						  " }}}1

--- a/compiler/gnat.vim
+++ b/compiler/gnat.vim
@@ -30,7 +30,7 @@ if !exists("g:gnat")
 
    call ada#Map_Menu (
       \ 'GNAT.Build',
-      \ '<F7>',
+      \ ':GnatMake',
       \ 'call gnat.Make ()')
    call ada#Map_Menu (
       \ 'GNAT.Pretty Print',

--- a/doc/ft_ada.txt
+++ b/doc/ft_ada.txt
@@ -156,7 +156,7 @@ environment.
 GNAT is the only free (beer and speech) Ada compiler available. There are
 several version available which differentiate in the licence terms used.
 
-The GNAT compiler plug-in will perform a compile on pressing <F7> and then
+The GNAT compiler plug-in will perform a compile on pressing |:GnatMake| and then
 immediately shows the result. You can set the project file to be used by
 setting:
  >
@@ -224,7 +224,7 @@ g:gnat.Error_Format	string
 					*compiler-vaxada* *compiler-compaqada*
 
 Dec Ada (also known by - in chronological order - VAX Ada, Dec Ada, Compaq Ada
-and HP Ada) is a fairly dated Ada 83 compiler. Support is basic: <F7> will
+and HP Ada) is a fairly dated Ada 83 compiler. Support is basic: |:GnatMake| will
 compile the current unit.
 
 The Dec Ada compiler expects the package name and not the file name to be
@@ -388,6 +388,9 @@ set makes no difference.
 
 :AdaTypes							   *:AdaTypes*
 		Toggles standard types (|g:ada_standard_types|) colour.
+
+:GnatMake							   *:GnatMake*
+		Calls |g:gnat.Make()|
 
 :GnatFind							   *:GnatFind*
 		Calls |g:gnat.Find()|


### PR DESCRIPTION
Change `<F7>` to `:GnatMake` because user could have already map something on `<F7>`.
Improvement of errors messages if no option `-gnatU` is set when compiling.
